### PR TITLE
Enable developer to modify height and width

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import Interface
 function App() {
   return (
     <div>
-      <Interface/>
+      <Interface width={600} height={100} />
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import Interface
 function App() {
   return (
     <div>
-      <Interface />
+      <Interface width={400} />
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import Interface
 function App() {
   return (
     <div>
-      <Interface width={600} height={100} />
+      <Interface />
     </div>
   );
 }

--- a/src/components/Interface/Interface.jsx
+++ b/src/components/Interface/Interface.jsx
@@ -1,9 +1,9 @@
 import Piano from "../Piano/Piano";
 import Warning from "../Warning/Warning";
 
-function Interface() {
+function Interface({width,height}) {
   return (<div className="interface">
-    <Piano />
+    <Piano width={width} height={height} />
     <Warning/>
   </div>)
 }

--- a/src/components/Interface/Interface.jsx
+++ b/src/components/Interface/Interface.jsx
@@ -1,9 +1,9 @@
 import Piano from "../Piano/Piano";
 import Warning from "../Warning/Warning";
 
-function Interface({width,height}) {
+function Interface({width,height,hideTitle}) {
   return (<div className="interface">
-    <Piano width={width} height={height} />
+    <Piano width={width} height={height} hideTitle={hideTitle} />
     <Warning/>
   </div>)
 }

--- a/src/components/Key/Key.css
+++ b/src/components/Key/Key.css
@@ -1,18 +1,27 @@
 .key {
-  margin: 5px;
+  margin: 2px;
+  /* border: 1px solid red; */
+  width: 100%;
+}
+.white, .gray, .black {
+  width: 80%;
+  padding: 0.5px;
 }
 .white {
-  height: 100px;
+  /* height: 100px; */
   margin: 0px;
+  height: 100%;
 }
 .gray {
-  height: 100px;
+  /* height: 100px; */
   margin: 0px;
   background-color: lightgray;
+  height: 100%;
 }
 
 .black {
-  height: 70px;
+  /* height: 70px; */
+  height: 70%;
   background-color: black;
   margin: 0px;
   color: white;

--- a/src/components/Key/Key.js
+++ b/src/components/Key/Key.js
@@ -35,7 +35,7 @@ const useTonePlayer = (note, sound) => {
   return { playSound };
 };
 
-function Key({note, color, sound}) {
+function Key({note, color, sound, width}) {
   const { playSound } = useTonePlayer(note, sound);
   return (
     <div className="key">

--- a/src/components/Piano/Piano.css
+++ b/src/components/Piano/Piano.css
@@ -3,4 +3,5 @@
 }
 .piano-parent {
   text-align: start;
+  /* border: 1px solid red; */
 }

--- a/src/components/Piano/Piano.js
+++ b/src/components/Piano/Piano.js
@@ -61,7 +61,7 @@ function Piano({width,height,hideTitle}) {
       {!hideTitle && <h2>Piano</h2>}
     <SelectedScaleDropdown handleScaleChange={handleScaleChange} selectedScaleName={selectedScaleName} />
     <SelectedSoundDropdown handleSoundChange={handleSoundChange} selectedSound={selectedSound}/>
-    <div className="piano" style={{width: width ? `${width}px` : defaultWidth,height: height ? `${height}px` : defaultHeight }}>
+    <div className="piano" style={{width: width && width > 400 ? `${width}px` : defaultWidth,height: height && height > 30 ? `${height}px` : defaultHeight }}>
         {selectedScale.map((note, key) => <Key width={width} sound={selectedSound} key={key} note={note.note} color={note.color} />)}
     </div>
   </div>

--- a/src/components/Piano/Piano.js
+++ b/src/components/Piano/Piano.js
@@ -8,7 +8,8 @@ function Piano({width,height,hideTitle}) {
   const [selectedScale, setSelectedScale] = useState(chromatic);
   const [selectedScaleName, setSelectedScaleName] = useState('chromatic');
   const [selectedSound, setSelectedSound] = useState('default');
-
+  const [defaultWidth, setDefaultWidth] = useState('600px');
+  const [defaultHeight,setDefaultHeight] = useState('100px')
   const handleScaleChange = (event) => {
     setSelectedScaleName(event.target.value)
     if (event.target.value === "Chromatic") {
@@ -60,7 +61,7 @@ function Piano({width,height,hideTitle}) {
       {!hideTitle && <h2>Piano</h2>}
     <SelectedScaleDropdown handleScaleChange={handleScaleChange} selectedScaleName={selectedScaleName} />
     <SelectedSoundDropdown handleSoundChange={handleSoundChange} selectedSound={selectedSound}/>
-    <div className="piano" style={{width:`${width}px`,height:`${height}px`}}>
+    <div className="piano" style={{width: width ? `${width}px` : defaultWidth,height: height ? `${height}px` : defaultHeight }}>
         {selectedScale.map((note, key) => <Key width={width} sound={selectedSound} key={key} note={note.note} color={note.color} />)}
     </div>
   </div>

--- a/src/components/Piano/Piano.js
+++ b/src/components/Piano/Piano.js
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import SelectedScaleDropdown from "../SelectedScaleDropdown/SelectedScaleDropdown";
 import SelectedSoundDropdown from "../SelectedSoundDropdown/SelectedSoundDropdown";
 import { chromatic, major, minor, minorPentatonic, minorBlues, majorPentatonic, mixolodian, harmonicMinor, dorian, majorBlues, klezmer, japanese, southEastAsian } from "../Scales/Scales";
-function Piano({width,height}) {
+function Piano({width,height,hideTitle}) {
   const [selectedScale, setSelectedScale] = useState(chromatic);
   const [selectedScaleName, setSelectedScaleName] = useState('chromatic');
   const [selectedSound, setSelectedSound] = useState('default');
@@ -57,7 +57,7 @@ function Piano({width,height}) {
 
   return (
   <div className="piano-parent">
-    <h2>Piano</h2>
+      {!hideTitle && <h2>Piano</h2>}
     <SelectedScaleDropdown handleScaleChange={handleScaleChange} selectedScaleName={selectedScaleName} />
     <SelectedSoundDropdown handleSoundChange={handleSoundChange} selectedSound={selectedSound}/>
     <div className="piano" style={{width:`${width}px`,height:`${height}px`}}>

--- a/src/components/Piano/Piano.js
+++ b/src/components/Piano/Piano.js
@@ -1,6 +1,6 @@
 import Key from "../Key/Key";
 import './Piano.css';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import SelectedScaleDropdown from "../SelectedScaleDropdown/SelectedScaleDropdown";
 import SelectedSoundDropdown from "../SelectedSoundDropdown/SelectedSoundDropdown";
 import { chromatic, major, minor, minorPentatonic, minorBlues, majorPentatonic, mixolodian, harmonicMinor, dorian, majorBlues, klezmer, japanese, southEastAsian } from "../Scales/Scales";
@@ -55,6 +55,17 @@ function Piano({width,height,hideTitle}) {
   const handleSoundChange = (event) => {
     setSelectedSound(event.target.value)
   }
+
+  useEffect(() => {
+    if (width < 400) {
+      console.warn('Warning: The width prop should be at least 400.');
+    }
+  }, [width]);
+  useEffect(() => {
+    if (height < 30) {
+      console.warn('Warning: The height prop should be at least 30.');
+    }
+  }, [height]);
 
   return (
   <div className="piano-parent">

--- a/src/components/Piano/Piano.js
+++ b/src/components/Piano/Piano.js
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import SelectedScaleDropdown from "../SelectedScaleDropdown/SelectedScaleDropdown";
 import SelectedSoundDropdown from "../SelectedSoundDropdown/SelectedSoundDropdown";
 import { chromatic, major, minor, minorPentatonic, minorBlues, majorPentatonic, mixolodian, harmonicMinor, dorian, majorBlues, klezmer, japanese, southEastAsian } from "../Scales/Scales";
-function Piano() {
+function Piano({width,height}) {
   const [selectedScale, setSelectedScale] = useState(chromatic);
   const [selectedScaleName, setSelectedScaleName] = useState('chromatic');
   const [selectedSound, setSelectedSound] = useState('default');
@@ -60,8 +60,8 @@ function Piano() {
     <h2>Piano</h2>
     <SelectedScaleDropdown handleScaleChange={handleScaleChange} selectedScaleName={selectedScaleName} />
     <SelectedSoundDropdown handleSoundChange={handleSoundChange} selectedSound={selectedSound}/>
-    <div className="piano">
-      {selectedScale.map((note, key) => <Key sound={selectedSound} key={key} note={note.note} color={note.color} />)}
+    <div className="piano" style={{width:`${width}px`,height:`${height}px`}}>
+        {selectedScale.map((note, key) => <Key width={width} sound={selectedSound} key={key} note={note.note} color={note.color} />)}
     </div>
   </div>
   )


### PR DESCRIPTION
The user can set width of piano using the _width_ prop, as long as the width is more than 400px. For instance, `<Interface width={500)/>` would mean the piano would be 500px wide. If the developer does not include the width prop, then the piano will be the default width, 600px.  If the developer tries to make the width less than 400px, they will see an error message in the console: "Warning: The width prop should be at least 400."

The user can set height of piano using the _height_ prop, as long as the height is more than 30px. For instance, `<Interface height={100)/>` would mean the piano would be 100px tall. If the developer does not include the height prop, then the height will be the default height, 100px.  If the developer tries to make the height less than 30px, they will see an error message in the console: "Warning: The height prop should be at least 30."

In the interface, there is a title, "Piano" that is displayed over the piano. The user also has the option to remove the title that is displayed over the piano, with the _hideTitle_ prop: `<Interface  hideTitle={true}/>`. This would enable them to make the interface even smaller. If the developer does not include the _hideTitle_ prop then the title will be displayed.